### PR TITLE
Disable caching of profile view

### DIFF
--- a/01-Login/www/templates/tab-profile.html
+++ b/01-Login/www/templates/tab-profile.html
@@ -1,4 +1,4 @@
-<ion-view view-title="Profile">
+<ion-view cache-view="false" view-title="Profile">
   <ion-content class="padding">
     <div ng-if="!auth.isAuthenticated()">
       <p>Please log in to view your profile.</p>


### PR DESCRIPTION
Disables view caching for the profile view. This resolves an issue where a stale profile is displayed if the user logs in, logs out, and logs in again with different credentials. When testing e.g. multiple social connections, one would expect to see the currently logged-in user's profile rather than the first user's profile.