### PR TITLE
Fix platform detection in auth config

### DIFF
--- a/angular/src/app/auth.config.ts.example
+++ b/angular/src/app/auth.config.ts.example
@@ -8,7 +8,8 @@ const { appId } = config;
 // Use `auth0Domain` in string interpolation below so that it doesn't
 // get replaced by the quickstart auto-packager
 const auth0Domain = domain;
+const iosOrAndroid = isPlatform("ios") || isPlatform("android");
 
-export const callbackUri = isPlatform("desktop")
-  ? "http://localhost:4200"
-  : `${appId}://${auth0Domain}/capacitor/${appId}/callback`;
+export const callbackUri = iosOrAndroid
+  ? `${appId}://${auth0Domain}/capacitor/${appId}/callback`
+  : "http://localhost:4200";

--- a/react/src/auth.config.ts.example
+++ b/react/src/auth.config.ts.example
@@ -11,4 +11,4 @@ const iosOrAndroid = isPlatform('ios') || isPlatform('android');
 
 export const callbackUri = iosOrAndroid
   ? `${appId}://${auth0Domain}/capacitor/${appId}/callback`
-  : 'http://localhost:4200';
+  : 'http://localhost:3000';

--- a/react/src/auth.config.ts.example
+++ b/react/src/auth.config.ts.example
@@ -7,7 +7,8 @@ const appId = "com.auth0.samples";
 // Use `auth0Domain` in string interpolation below so that it doesn't
 // get replaced by the quickstart auto-packager
 const auth0Domain = domain;
+const iosOrAndroid = isPlatform('ios') || isPlatform('android');
 
-export const callbackUri = isPlatform("desktop")
-  ? "http://localhost:3000"
-  : `${appId}://${auth0Domain}/capacitor/${appId}/callback`;
+export const callbackUri = iosOrAndroid
+  ? `${appId}://${auth0Domain}/capacitor/${appId}/callback`
+  : 'http://localhost:4200';


### PR DESCRIPTION
This favours checking `isPlatform('ios') && isPlatform('android')` vs `!isPlatform('desktop')` for detecting the mobile platform, as the latter appears to return `true` when running in an Android emulator, causing the app to use the wrong callback.

Ref #74 