### PR TITLE
Update browser-tools orb to fix chrome download

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  browser-tools: circleci/browser-tools@1.1.0
+  browser-tools: circleci/browser-tools@1.4.3
 executors:
   build-executor:
     docker:


### PR DESCRIPTION
Updates `circleci/browser-tools` to the latest version to fix the chrome download