### PR TITLE
Update to latest browser-tools orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  browser-tools: circleci/browser-tools@1.4.3
+  browser-tools: circleci/browser-tools@1.4.6
 executors:
   build-executor:
     docker:


### PR DESCRIPTION
It seems there were a few releases after the one we updated to in #599 that corrected some issues, the CI isn #620 is failing due to the chromedriver URL not being found so I'm hoping one of those changes it fixes it